### PR TITLE
Update support URLs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set (PROJECT_VERSION "1.4.0")
 
 set (PACKAGE "${PROJECT_NAME}")
 set (VERSION "${PROJECT_VERSION}")
-set (PACKAGE_BUGREPORT "support@taskwarrior.org")
+set (PACKAGE_BUGREPORT "support@gothenburgbitfactory.org")
 set (PACKAGE_NAME "${PACKAGE}")
 set (PACKAGE_TARNAME "${PACKAGE}")
 set (PACKAGE_VERSION "${VERSION}")

--- a/doc/man/clog.1.in
+++ b/doc/man/clog.1.in
@@ -129,7 +129,7 @@ For more information, see:
 
 .TP
 The official site at
-<https://taskwarrior.org/docs/clog/>
+<https://gothenburgbitfactory.org/clog/docs/>
 
 .TP
 The official code repository at
@@ -137,7 +137,7 @@ The official code repository at
 
 .TP
 You can contact the project by emailing
-<support@taskwarrior.org>
+<support@gothenburgbitfactory.org>
 
 .SH REPORTING BUGS
 .TP


### PR DESCRIPTION
Replace two old support URLs still pointing to 'taskwarrior.org' with 'gothenburgbitfactory.org'.